### PR TITLE
Hide interpreter sort interface behind public function

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -132,7 +131,7 @@ func (a *App) List() error {
 	}
 	// Ensure interpreters are sorted latest to oldest regardless of
 	// any filepath based sorting from ReadDir
-	sort.Sort(interpreters)
+	interpreter.Sort(interpreters)
 
 	a.Logger.WithField("interpreters", interpreters).Debugln("Found python3 interpreters")
 
@@ -238,7 +237,7 @@ func (a *App) LaunchLatest(args []string) error {
 		return fmt.Errorf("no python interpreters found on $PATH")
 	}
 
-	sort.Sort(interpreters)
+	interpreter.Sort(interpreters)
 
 	a.Logger.WithField("interpreters", interpreters).Debugln("Found python3 interpreters")
 
@@ -265,7 +264,7 @@ func (a *App) LaunchMajor(major int, args []string) error {
 
 	// Create and populate a list of all the python interpreters that
 	// satisfy the specified major version
-	var supportingInterpreters interpreter.List
+	var supportingInterpreters []interpreter.Interpreter
 	for _, python := range interpreters {
 		if python.SatisfiesMajor(major) {
 			supportingInterpreters = append(supportingInterpreters, python)
@@ -278,7 +277,7 @@ func (a *App) LaunchMajor(major int, args []string) error {
 	}
 
 	// Sort so the latest supporting interpreter is first
-	sort.Sort(supportingInterpreters)
+	interpreter.Sort(supportingInterpreters)
 
 	a.Logger.WithField("matching interpreters", supportingInterpreters).Debugln("Found matching interpreters")
 
@@ -304,7 +303,7 @@ func (a *App) LaunchExact(major, minor int, args []string) error {
 
 	// Create and populate a list of all the python interpreters that
 	// satisfy the specify major version
-	var supportingInterpreters interpreter.List
+	var supportingInterpreters []interpreter.Interpreter
 	for _, python := range interpreters {
 		if python.SatisfiesExact(major, minor) {
 			supportingInterpreters = append(supportingInterpreters, python)
@@ -317,7 +316,7 @@ func (a *App) LaunchExact(major, minor int, args []string) error {
 	}
 
 	// Sort so the latest supporting interpreter is first
-	sort.Sort(supportingInterpreters)
+	interpreter.Sort(supportingInterpreters)
 
 	a.Logger.WithField("matching interpreters", supportingInterpreters).Debugln("Found matching interpreters")
 
@@ -453,7 +452,7 @@ func (a *App) parseShebang(shebang string) string {
 
 // getAllPythonInterpreters does exactly what it says on the tin
 // it searches through $PATH and returns a list of all python interpreters
-func (a *App) getAllPythonInterpreters() (interpreter.List, error) {
+func (a *App) getAllPythonInterpreters() ([]interpreter.Interpreter, error) {
 	a.Logger.Debugln("Checking $PATH environment variable")
 	paths := a.getPathEntries()
 

--- a/pkg/interpreter/interpreter.go
+++ b/pkg/interpreter/interpreter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -112,31 +113,31 @@ func (i Interpreter) SatisfiesExact(major, minor int) bool {
 	return i.Major == major && i.Minor == minor
 }
 
-// List represents a list of python interpreters
+// byVersion represents a list of python interpreters
 // and enables us to implement sorting which is how we tell which one is
 // the latest python version without relying on filesystem lexical order
 // which may not be deterministic
-type List []Interpreter
+type byVersion []Interpreter
 
 // Len returns the number of interpreters in the list
-func (il List) Len() int {
-	return len(il)
+func (bv byVersion) Len() int {
+	return len(bv)
 }
 
 // Less returns whether the element with index i should sort
 // less than element with index j
 // Note: we reverse it here and actually test for greater than
 // because we want the latest interpreter to be at the front of the slice
-func (il List) Less(i, j int) bool {
+func (bv byVersion) Less(i, j int) bool {
 	// Short circuit, if i.Major > j.Major, return true straight away
-	if il[i].Major > il[j].Major {
+	if bv[i].Major > bv[j].Major {
 		return true
 	}
 
 	// Only get here if majors are equal or i.Major < j.Major
-	if il[i].Major == il[j].Major {
+	if bv[i].Major == bv[j].Major {
 		// If majors are equal, compare minors
-		return il[i].Minor > il[j].Minor
+		return bv[i].Minor > bv[j].Minor
 	}
 
 	// Now only condition remaining is i.Major < j.Major
@@ -145,8 +146,8 @@ func (il List) Less(i, j int) bool {
 }
 
 // Swap swaps the position of two elements in the list
-func (il List) Swap(i, j int) {
-	il[i], il[j] = il[j], il[i]
+func (bv byVersion) Swap(i, j int) {
+	bv[i], bv[j] = bv[j], bv[i]
 }
 
 // GetAll looks under each path in `paths` for valid python
@@ -156,8 +157,8 @@ func (il List) Swap(i, j int) {
 // be populated by searching through $PATH, meaning we don't have to bother checking
 // if files are executable etc and $PATH is unlikely to be cluttered with random
 // files called `python` unless they are the interpreter executables
-func GetAll(paths []string) (List, error) {
-	var interpreters List
+func GetAll(paths []string) ([]Interpreter, error) {
+	var interpreters []Interpreter
 
 	for _, path := range paths {
 		found, err := getPythonInterpreters(path)
@@ -170,9 +171,16 @@ func GetAll(paths []string) (List, error) {
 	return interpreters, nil
 }
 
+func Sort(interpreters []Interpreter) []Interpreter {
+	pythons := interpreters
+	sort.Sort(byVersion(pythons))
+
+	return pythons
+}
+
 // getPythonInterpreters accepts an absolute path to a directory under which
 // it will search for python interpreters, returning any it finds
-func getPythonInterpreters(dir string) (List, error) {
+func getPythonInterpreters(dir string) ([]Interpreter, error) {
 	contents, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("could not read contents of %s: %w", dir, err)

--- a/pkg/interpreter/interpreter_test.go
+++ b/pkg/interpreter/interpreter_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
-	"sort"
 	"testing"
 )
 
@@ -182,15 +181,15 @@ func TestInterpreter_String(t *testing.T) {
 	}
 }
 
-func TestListSort(t *testing.T) {
+func TestInterpreterSort(t *testing.T) {
 	tests := []struct {
 		name string
-		list List
-		want List
+		list []Interpreter
+		want []Interpreter
 	}{
 		{
 			name: "test",
-			list: List{
+			list: []Interpreter{
 				// We don't intialise paths because it doesn't matter for sorting
 				{
 					Major: 3,
@@ -233,7 +232,7 @@ func TestListSort(t *testing.T) {
 					Minor: 6,
 				},
 			},
-			want: List{
+			want: []Interpreter{
 				{
 					Major: 4,
 					Minor: 10,
@@ -283,7 +282,7 @@ func TestListSort(t *testing.T) {
 			if len(tt.list) != len(tt.want) {
 				t.Fatalf("len(list): %d, len(want): %d. Check the test cases", len(tt.list), len(tt.want))
 			}
-			sort.Sort(tt.list)
+			Sort(byVersion(tt.list))
 			// Now tt.list should be sorted and match tt.want
 			if !reflect.DeepEqual(tt.list, tt.want) {
 				t.Errorf("got %v, wanted %v", tt.list, tt.want)
@@ -428,13 +427,13 @@ func Test_getPythonInterpreters(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    List
+		want    []Interpreter
 		wantErr bool
 	}{
 		{
 			name: "test",
 			args: args{dir: testDir},
-			want: List{
+			want: []Interpreter{
 				{
 					Major: 3,
 					Minor: 10,
@@ -475,7 +474,7 @@ func TestGetAllPythonInterpreters(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    List
+		want    []Interpreter
 		wantErr bool
 	}{
 		{
@@ -485,7 +484,7 @@ func TestGetAllPythonInterpreters(t *testing.T) {
 				filepath.Join(testDir, "pythonpath2"),
 				filepath.Join(testDir, "pythonpath3"),
 			}},
-			want: List{
+			want: []Interpreter{
 				{
 					Major: 3,
 					Minor: 10,
@@ -553,7 +552,7 @@ func BenchmarkGetAllPythonInterpreters(b *testing.B) {
 }
 
 func BenchmarkInterpreterSort(b *testing.B) {
-	input := List(List{
+	input := []Interpreter([]Interpreter{
 		{
 			Major: 3,
 			Minor: 7,
@@ -601,7 +600,7 @@ func BenchmarkInterpreterSort(b *testing.B) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		sort.Sort(input)
+		Sort(byVersion(input))
 	}
 }
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->

Hides the byVersion sort interface for interpreters behind
a top level function in package interpreter, simplifying
the api for the rest of the project.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Just cleans things up a bit as now the CLI doesn't have to care
that there is a `byVersion` type

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
<!-- If you ran a nox session for example -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
